### PR TITLE
Fix day order and typo

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -15,7 +15,7 @@
 </md-card>
 <md-card class="board-card">
   <md-card-header>
-    <md-card-title>Wekstart</md-card-title>
+    <md-card-title>Weekstart</md-card-title>
     <md-card-subtitle></md-card-subtitle>
   </md-card-header>
   <md-card-content>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -17,8 +17,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   public languages: Language[] = [];
   public weekStartDays: WeekStartWithTranslation[] = [
-    new WeekStartWithTranslation(WeekStart.Monday, 'Monday'),
-    new WeekStartWithTranslation(WeekStart.Sunday, 'Sunday')
+    new WeekStartWithTranslation(WeekStart.Sunday, 'Sunday'),
+    new WeekStartWithTranslation(WeekStart.Monday, 'Monday')
   ];
   private subscriptions: Subscription[] = [];
 


### PR DESCRIPTION
Under "Settings", there is a typo, 'Wekstart' instead of 'Weekstart'.
Regarding the order of the days, it feels more natural to first have 'Sunday' and then 'Monday'