### PR TITLE
fixed login bug

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,3 @@
 {
-  "apiKey": "41485cd87d154168dd6db06cdd3ffd69"
+  "apiKey": "28fceee1d49ddeff46c2cd6c4ca067ba"
 }


### PR DESCRIPTION
There was a problem with the login process. I think the API key was expired. I created a new one with my personal account.