### PR TITLE
fix: Display of the avatar

### DIFF
--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -1,4 +1,3 @@
-import {Board} from './board';
 export interface Prefs {
   sendSummaries: boolean;
   minutesBetweenSummaries: number;
@@ -36,4 +35,5 @@ export class User {
   uploadedAvatarHash?: any;
   premiumFeatures: any[];
   idBoardsPinned?: any;
+  avatarUrl: string;
 }

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -1,7 +1,7 @@
 <div class="top">
   <mat-toolbar color="primary">
-    <img *ngIf="user?.avatarHash" class="profile-picture"
-         src="https://trello-avatars.s3.amazonaws.com/{{user?.avatarHash}}/50.png"
+    <img *ngIf="user?.avatarUrl" class="profile-picture"
+         src="{{user?.avatarUrl}}/50.png"
          alt="{{user?.fullName}}">
     <span>{{user?.fullName}}</span>
   </mat-toolbar>


### PR DESCRIPTION
They updated the hosting location of Trello users’ avatars so that their URI includes the member ID of the user. All of the user’s avatars are now nested under their own member ID. Additionally, they are hosted on a new domain.

Previously, the avatarUrl field on a member looked like this: https://trello-avatars.s3.amazonaws.com/fc8faaaee46666a4eb8b626c08933e16/170.png 10

Now, the route looks like this:
https://trello-members.s3.amazonaws.com/5589c3ea49b40cedc28cf70e/fc8faaaee46666a4eb8b626c08933e16/170.png 7

Added to 'calendar-for-trello/src/app/models/user.ts' the field: 'avatarUrl' and pasted it into 'calendar-for-trello/src/app/sidebar/sidebar.component.html'